### PR TITLE
feat: custom exit status-code for lnd interceptor

### DIFF
--- a/cmd/lnd/main.go
+++ b/cmd/lnd/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	// Load the configuration, and parse any command line options. This
 	// function will also set up logging properly.
-	loadedConfig, err := lnd.LoadConfig(shutdownInterceptor)
+	loadedConfig, err := lnd.LoadConfig(*shutdownInterceptor)
 	if err != nil {
 		if e, ok := err.(*flags.Error); !ok || e.Type != flags.ErrHelp {
 			// Print error if not due to help request.
@@ -34,9 +34,20 @@ func main() {
 	// Call the "real" main in a nested manner so the defers will properly
 	// be executed in the case of a graceful shutdown.
 	if err = lnd.Main(
-		loadedConfig, lnd.ListenerCfg{}, shutdownInterceptor,
+		loadedConfig, lnd.ListenerCfg{}, *shutdownInterceptor,
 	); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	defer func() {
+		fmt.Println("Shutdown complete")
+		err := loadedConfig.LogWriter.Close()
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+		}
+
+		if shutdownInterceptor.GetExitCode() == 1 {
+			os.Exit(1)
+		}
+	}()
 }

--- a/lnd.go
+++ b/lnd.go
@@ -192,13 +192,6 @@ type ListenerCfg struct {
 // This function starts all main system components then blocks until a signal
 // is received on the shutdownChan at which point everything is shut down again.
 func Main(cfg *Config, lisCfg ListenerCfg, interceptor signal.Interceptor) error {
-	defer func() {
-		ltndLog.Info("Shutdown complete\n")
-		err := cfg.LogWriter.Close()
-		if err != nil {
-			ltndLog.Errorf("Could not close log rotator: %v", err)
-		}
-	}()
 
 	// Show version at startup.
 	ltndLog.Infof("Version: %s commit=%s, build=%s, logging=%s, debuglevel=%s",

--- a/mobile/bindings.go
+++ b/mobile/bindings.go
@@ -75,7 +75,7 @@ func Start(extraArgs string, rpcReady Callback) {
 
 	// Load the configuration, and parse the extra arguments as command
 	// line options. This function will also set up logging properly.
-	loadedConfig, err := lnd.LoadConfig(shutdownInterceptor)
+	loadedConfig, err := lnd.LoadConfig(*shutdownInterceptor)
 	if err != nil {
 		atomic.StoreInt32(&lndStarted, 0)
 		_, _ = fmt.Fprintln(os.Stderr, err)
@@ -106,7 +106,7 @@ func Start(extraArgs string, rpcReady Callback) {
 		defer close(quit)
 
 		if err := lnd.Main(
-			loadedConfig, cfg, shutdownInterceptor,
+			loadedConfig, cfg, *shutdownInterceptor,
 		); err != nil {
 			if e, ok := err.(*flags.Error); ok &&
 				e.Type == flags.ErrHelp {


### PR DESCRIPTION
This commit adds an ability to interceptor to have custom exit status-codes for interceptor that allows to exit after an graceful exit

Signed-off-by: DarthBenro008 <hkpdev008@gmail.com>

#### Pull Request Checklist

- [ ] All changes are Go version 1.15 compliant
- [ ] Your PR passes all CI checks. If a check cannot be passed for a justifiable reason, that reason must be stated in the commit message and PR description.
- [ ] If this is your first time contributing, we recommend you read the [Code Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md)
   - [ ] The code being submitted is commented according to [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation)
   - [ ] Commits have a logical structure according to [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure)
- [ ] For new code: Code is accompanied by tests which exercise both the positive and negative (error paths) conditions (if applicable)
- [ ] For bug fixes: If possible, code is accompanied by new tests which trigger the bug being fixed to prevent regressions
- [ ] Any new logging statements use an appropriate subsystem and logging level
- [ ] For code and documentation: lines are wrapped at 80 characters (the tab character should be counted as 8 characters, not 4, as some IDEs do per default)
- [ ] A description of your changes [should be added to running the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes) for the milestone your change will land in.
